### PR TITLE
Fixes crash when performing variant annotation without filtering.

### DIFF
--- a/nf-iap.nf
+++ b/nf-iap.nf
@@ -172,9 +172,13 @@ workflow {
       params.genome_snpsift_annotate_db = params.genomes[params.genome].gonl
       include snpeff_gatk_annotate from './workflows/snpeff_gatk_annotate.nf' params(params)
 
-      if (gatk_variantfiltration.out){
-        snpeff_gatk_annotate(gatk_variantfiltration.out)
-      }else if(input_vcf){
+      if (params.variantFiltration){
+        if (gatk_variantfiltration.out){
+          snpeff_gatk_annotate(gatk_variantfiltration.out)
+        }else if(input_vcf){
+          snpeff_gatk_annotate(input_vcf)
+        }
+      }else if (input_vcf){
         snpeff_gatk_annotate(input_vcf)
       }
     }


### PR DESCRIPTION
When variant annotation is performed without filtering the pipeline crashes. This crash is caused by the `gatk_variantfiltration.out` variable not being created when filtering is not performed.
I'm not familiar with nextflow so I just added an extra if statement around this variable to prevent the issue. This does make my fix rather ugly though. A check to see if the variable exists might be prettier.